### PR TITLE
Update Upcase link on index page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: default
 
 <p>I host the <a href="http://giantrobots.fm">Giant Robots Podcast</a>, run <a
                  href="https://formkeep.com">FormKeep</a>, <br> and co-created <a
-  href="http://upcase.com">Upcase</a>, <a href="https://www.trailmix.life">Trailmix</a>, and <a href="https://www.briefs.fm">Briefs</a>.</p>
+  href="https://thoughtbot.com/upcase/">Upcase</a>, <a href="https://www.trailmix.life">Trailmix</a>, and <a href="https://www.briefs.fm">Briefs</a>.</p>
 
 <p>You might enjoy reading <a href="http://www.benorenstein.com/blog">my blog</a> or watching <a href="/talks">one of my talks</a>.</p>
 


### PR DESCRIPTION
Upcase has been moved to be under the thoughtbot.com domain. This
updates the link on the homepage to point to this new location.
