### PR TITLE
Update Confreaks link

### DIFF
--- a/talks/index.html
+++ b/talks/index.html
@@ -51,7 +51,7 @@ layout: default
 
 <article class="talk">
   <p>You can find even more talks on <a
-    href="http://www.confreaks.com/presenters/780-ben-orenstein">my Confreaks
+    href="https://confreaks.tv/presenters/ben-orenstein">my Confreaks
   page</a>.</p>
 </article>
 


### PR DESCRIPTION
I noticed the link to your Confreaks page was 404ing the other day — looks like they moved presenters to a new TLD at some point.